### PR TITLE
Revise LaTeX reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Extensies geven VS Code superkrachten voor LaTeX.
 - 📌 Handig voor samenwerken
 
 ### ✅ LaTeX – LanguageTool (Optioneel maar handig)
-- 🔍 Zoek: `LaTeX`
+- 🔍 Zoek: `LTeX – LanguageTool grammar/spell checking`
 - 👤 Auteur: Julian Valentin
 - 📝 Spellingscontrole en grammatica voor Nederlands
 


### PR DESCRIPTION
Bij extensies was de zoekterm niet precies genoeg om de juiste extensie te vinden. Ik heb het aangepast naar iets precieser, waarbij de juiste extensie op de eerste plaats staat.